### PR TITLE
Export architecture_independent flag in package.xml

### DIFF
--- a/angles/package.xml
+++ b/angles/package.xml
@@ -17,4 +17,8 @@
   <url>http://ros.org/wiki/angles</url>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>


### PR DESCRIPTION
This package doesn't have any binaries in it, so it can be marked as architecture independent.

Tested on the RPM buildfarm (http://csc.mcs.sdsmt.edu/jenkins/):
- [x] No regressions
- [x] No binaries installed

See:
- https://github.com/ros/rosdistro/issues/4037
- https://github.com/ros-infrastructure/bloom/pull/270
- http://www.ros.org/reps/rep-0127.html#architecture-independent

Thanks!
