### PR TITLE
Adding export lines to CMakeLists.txt

### DIFF
--- a/angles/CMakeLists.txt
+++ b/angles/CMakeLists.txt
@@ -20,6 +20,5 @@ install(DIRECTORY include/${PROJECT_NAME}/
 include_directories(include)
 
 ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
 
 ament_package()

--- a/angles/CMakeLists.txt
+++ b/angles/CMakeLists.txt
@@ -19,4 +19,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 include_directories(include)
 
+ament_export_include_directories(include)
+ament_export_libraries(${PROJECT_NAME})
+
 ament_package()


### PR DESCRIPTION
This is needed for dependent packages to pick up the include
directory.