### PR TITLE
Added support for "large limits"

### DIFF
--- a/angles/include/angles/angles.h
+++ b/angles/include/angles/angles.h
@@ -198,6 +198,81 @@ namespace angles
   /*!
    * \function
    *
+   * \brief Returns the delta from `from_angle` to `to_angle`, making sure it does not violate limits specified by `left_limit` and `right_limit`.
+   * This function is similar to `shortest_angular_distance_with_limits()`, with the main difference that it accepts limits outside the `[-M_PI, M_PI]` range.
+   * Even if this is quite uncommon, one could indeed consider revolute joints with large rotation limits, e.g., in the range `[-2*M_PI, 2*M_PI]`.
+   *
+   * In this case, a strict requirement is to have `left_limit` smaller than `right_limit`.
+   * Note also that `from` must lie inside the valid range, while `to` does not need to.
+   * In fact, this function will evaluate the shortest (valid) angle `shortest_angle` so that `from+shortest_angle` equals `to` up to an integer multiple of `2*M_PI`.
+   * As an example, a call to `shortest_angular_distance_with_large_limits(0, 10.5*M_PI, -2*M_PI, 2*M_PI, shortest_angle)` will return `true`, with `shortest_angle=0.5*M_PI`.
+   * This is because `from` and `from+shortest_angle` are both inside the limits, and `fmod(to+shortest_angle, 2*M_PI)` equals `fmod(to, 2*M_PI)`.
+   * On the other hand, `shortest_angular_distance_with_large_limits(10.5*M_PI, 0, -2*M_PI, 2*M_PI, shortest_angle)` will return false, since `from` is not in the valid range.
+   * Finally, note that the call `shortest_angular_distance_with_large_limits(0, 10.5*M_PI, -2*M_PI, 0.1*M_PI, shortest_angle)` will also return `true`.
+   * However, `shortest_angle` in this case will be `-1.5*M_PI`.
+   *
+   * Note that you do not need to call this function directly: `shortest_angular_distance_with_limits` will call it if the given limits are "large".
+   *
+   * \return true if `left_limit < right_limit` and if "from" and "from+shortest_angle" positions are within the valid interval, false otherwise.
+   * \param from - "from" angle.
+   * \param to - "to" angle.
+   * \param left_limit - left limit of valid interval, must be smaller than right_limit.
+   * \param right_limit - right limit of valid interval, must be greater than left_limit.
+   * \param shortest_angle - result of the shortest angle calculation.
+   */
+  static inline bool shortest_angular_distance_with_large_limits(double from, double to, double left_limit, double right_limit, double &shortest_angle)
+  {
+    // Shortes steps in the two directions
+    double delta = shortest_angular_distance(from, to);
+    double delta_2pi = two_pi_complement(delta);
+
+    // "sort" distances so that delta is shorter than delta_2pi
+    if(std::fabs(delta) > std::fabs(delta_2pi))
+      std::swap(delta, delta_2pi);
+
+    if(left_limit > right_limit) {
+      // If limits are something like [PI/2 , -PI/2] it actually means that we
+      // want rotations to be in the interval [-PI,PI/2] U [PI/2,PI], ie, the
+      // half unit circle not containing the 0. This is already gracefully
+      // handled by shortest_angular_distance_with_limits, and therefore this
+      // function should not be called at all. However, if one has limits that
+      // are larger than PI, the same rationale behind shortest_angular_distance_with_limits
+      // does not hold, ie, M_PI+x should not be directly equal to -M_PI+x.
+      // In this case, the correct way of getting the shortest solution is to
+      // properly set the limits, eg, by saying that the interval is either
+      // [PI/2, 3*PI/2] or [-3*M_PI/2, -M_PI/2]. For this reason, here we
+      // return false by default.
+      shortest_angle = delta;
+      return false;
+    }
+
+    // Check in which direction we should turn (clockwise or counter-clockwise).
+
+    // start by trying with the shortest angle (delta).
+    double to2 = from + delta;
+    if(left_limit <= to2 && to2 <= right_limit) {
+      // we can move in this direction: return success if the "from" angle is inside limits
+      shortest_angle = delta;
+      return left_limit <= from && from <= right_limit;
+    }
+
+    // delta is not ok, try to move in the other direction (using its complement)
+    to2 = from + delta_2pi;
+    if(left_limit <= to2 && to2 <= right_limit) {
+      // we can move in this direction: return success if the "from" angle is inside limits
+      shortest_angle = delta_2pi;
+      return left_limit <= from && from <= right_limit;
+    }
+
+    // nothing works: we always go outside limits
+    shortest_angle = delta; // at least give some "coherent" result
+    return false;
+  }
+
+
+  /*!
+   * \function
+   *
    * \brief Returns the delta from "from_angle" to "to_angle" making sure it does not violate limits specified by left_limit and right_limit.
    * The valid interval of angular positions is [left_limit,right_limit]. E.g., [-0.25,0.25] is a 0.5 radians wide interval that contains 0.
    * But [0.25,-0.25] is a 2*M_PI-0.5 wide interval that contains M_PI (but not 0).
@@ -214,6 +289,13 @@ namespace angles
    */
   static inline bool shortest_angular_distance_with_limits(double from, double to, double left_limit, double right_limit, double &shortest_angle)
   {
+
+    // If either left_limit or right_limit is outside the "standard" unit circle,
+    // call shortest_angular_distance_with_large_limits instead
+    if(std::fabs(left_limit) > M_PI || std::fabs(right_limit) > M_PI)
+    {
+      return shortest_angular_distance_with_large_limits(from, to, left_limit, right_limit, shortest_angle);
+    }
 
     double min_delta = -2*M_PI;
     double max_delta = 2*M_PI;

--- a/angles/include/angles/angles.h
+++ b/angles/include/angles/angles.h
@@ -211,8 +211,6 @@ namespace angles
    * Finally, note that the call `shortest_angular_distance_with_large_limits(0, 10.5*M_PI, -2*M_PI, 0.1*M_PI, shortest_angle)` will also return `true`.
    * However, `shortest_angle` in this case will be `-1.5*M_PI`.
    *
-   * Note that you do not need to call this function directly: `shortest_angular_distance_with_limits` will call it if the given limits are "large".
-   *
    * \return true if `left_limit < right_limit` and if "from" and "from+shortest_angle" positions are within the valid interval, false otherwise.
    * \param from - "from" angle.
    * \param to - "to" angle.
@@ -289,13 +287,6 @@ namespace angles
    */
   static inline bool shortest_angular_distance_with_limits(double from, double to, double left_limit, double right_limit, double &shortest_angle)
   {
-
-    // If either left_limit or right_limit is outside the "standard" unit circle,
-    // call shortest_angular_distance_with_large_limits instead
-    if(std::fabs(left_limit) > M_PI || std::fabs(right_limit) > M_PI)
-    {
-      return shortest_angular_distance_with_large_limits(from, to, left_limit, right_limit, shortest_angle);
-    }
 
     double min_delta = -2*M_PI;
     double max_delta = 2*M_PI;

--- a/angles/include/angles/angles.h
+++ b/angles/include/angles/angles.h
@@ -222,7 +222,7 @@ namespace angles
    */
   static inline bool shortest_angular_distance_with_large_limits(double from, double to, double left_limit, double right_limit, double &shortest_angle)
   {
-    // Shortes steps in the two directions
+    // Shortest steps in the two directions
     double delta = shortest_angular_distance(from, to);
     double delta_2pi = two_pi_complement(delta);
 

--- a/angles/test/CMakeLists.txt
+++ b/angles/test/CMakeLists.txt
@@ -1,5 +1,4 @@
 if (CATKIN_ENABLE_TESTING)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
   catkin_add_gtest(utest utest.cpp)
   catkin_add_nosetests(utest.py)
 endif (CATKIN_ENABLE_TESTING)

--- a/angles/test/CMakeLists.txt
+++ b/angles/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 if (CATKIN_ENABLE_TESTING)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
   catkin_add_gtest(utest utest.cpp)
   catkin_add_nosetests(utest.py)
 endif (CATKIN_ENABLE_TESTING)

--- a/angles/test/utest.cpp
+++ b/angles/test/utest.cpp
@@ -165,7 +165,7 @@ TEST(Angles, normalize_angle_positive)
  EXPECT_NEAR(M_PI/2, normalize_angle_positive(5*M_PI/2), epsilon);
  EXPECT_NEAR(M_PI/2, normalize_angle_positive(9*M_PI/2), epsilon);
  EXPECT_NEAR(M_PI/2, normalize_angle_positive(-3*M_PI/2), epsilon);
-
+ 
 }
 
 

--- a/angles/test/utest.cpp
+++ b/angles/test/utest.cpp
@@ -165,7 +165,7 @@ TEST(Angles, normalize_angle_positive)
  EXPECT_NEAR(M_PI/2, normalize_angle_positive(5*M_PI/2), epsilon);
  EXPECT_NEAR(M_PI/2, normalize_angle_positive(9*M_PI/2), epsilon);
  EXPECT_NEAR(M_PI/2, normalize_angle_positive(-3*M_PI/2), epsilon);
- 
+
 }
 
 
@@ -195,7 +195,7 @@ TEST(Angles, normalize_angle)
  EXPECT_NEAR(M_PI/2, normalize_angle(5*M_PI/2), epsilon);
  EXPECT_NEAR(M_PI/2, normalize_angle(9*M_PI/2), epsilon);
  EXPECT_NEAR(M_PI/2, normalize_angle(-3*M_PI/2), epsilon);
-
+ 
 }
 
 TEST(Angles, shortest_angular_distance)

--- a/angles/test/utest.cpp
+++ b/angles/test/utest.cpp
@@ -80,29 +80,29 @@ TEST(Angles, shortestDistanceWithLargeLimits)
   bool result;
 
   // 'delta' is valid
-  result = angles::shortest_angular_distance_with_limits(0, 10.5*M_PI, -2*M_PI, 2*M_PI, shortest_angle);
+  result = angles::shortest_angular_distance_with_large_limits(0, 10.5*M_PI, -2*M_PI, 2*M_PI, shortest_angle);
   EXPECT_TRUE(result);
   EXPECT_NEAR(shortest_angle, 0.5*M_PI, 1e-6);
 
   // 'delta' is not valid, but 'delta_2pi' is
-  result = angles::shortest_angular_distance_with_limits(0, 10.5*M_PI, -2*M_PI, 0.1*M_PI, shortest_angle);
+  result = angles::shortest_angular_distance_with_large_limits(0, 10.5*M_PI, -2*M_PI, 0.1*M_PI, shortest_angle);
   EXPECT_TRUE(result);
   EXPECT_NEAR(shortest_angle, -1.5*M_PI, 1e-6);
 
   // neither 'delta' nor 'delta_2pi' are valid
-  result = angles::shortest_angular_distance_with_limits(2*M_PI, M_PI, 2*M_PI-0.1, 2*M_PI+0.1, shortest_angle);
+  result = angles::shortest_angular_distance_with_large_limits(2*M_PI, M_PI, 2*M_PI-0.1, 2*M_PI+0.1, shortest_angle);
   EXPECT_FALSE(result);
 
   // start position outside limits
-  result = angles::shortest_angular_distance_with_limits(10.5*M_PI, 0, -2*M_PI, 2*M_PI, shortest_angle);
+  result = angles::shortest_angular_distance_with_large_limits(10.5*M_PI, 0, -2*M_PI, 2*M_PI, shortest_angle);
   EXPECT_FALSE(result);
 
   // invalid limits (lower > upper)
-  result = angles::shortest_angular_distance_with_limits(0, 0.1, 2*M_PI, -2*M_PI, shortest_angle);
+  result = angles::shortest_angular_distance_with_large_limits(0, 0.1, 2*M_PI, -2*M_PI, shortest_angle);
   EXPECT_FALSE(result);
 
   // specific test case
-  result = angles::shortest_angular_distance_with_limits(0.999507, 1.0, -20*M_PI, 20*M_PI, shortest_angle);
+  result = angles::shortest_angular_distance_with_large_limits(0.999507, 1.0, -20*M_PI, 20*M_PI, shortest_angle);
   EXPECT_TRUE(result);
   EXPECT_NEAR(shortest_angle, 0.000493, 1e-6);
 }

--- a/angles/test/utest.cpp
+++ b/angles/test/utest.cpp
@@ -73,6 +73,41 @@ TEST(Angles, shortestDistanceWithLimits){
 
 }
 
+
+TEST(Angles, shortestDistanceWithLargeLimits)
+{
+  double shortest_angle;
+  bool result;
+
+  // 'delta' is valid
+  result = angles::shortest_angular_distance_with_limits(0, 10.5*M_PI, -2*M_PI, 2*M_PI, shortest_angle);
+  EXPECT_TRUE(result);
+  EXPECT_NEAR(shortest_angle, 0.5*M_PI, 1e-6);
+
+  // 'delta' is not valid, but 'delta_2pi' is
+  result = angles::shortest_angular_distance_with_limits(0, 10.5*M_PI, -2*M_PI, 0.1*M_PI, shortest_angle);
+  EXPECT_TRUE(result);
+  EXPECT_NEAR(shortest_angle, -1.5*M_PI, 1e-6);
+
+  // neither 'delta' nor 'delta_2pi' are valid
+  result = angles::shortest_angular_distance_with_limits(2*M_PI, M_PI, 2*M_PI-0.1, 2*M_PI+0.1, shortest_angle);
+  EXPECT_FALSE(result);
+
+  // start position outside limits
+  result = angles::shortest_angular_distance_with_limits(10.5*M_PI, 0, -2*M_PI, 2*M_PI, shortest_angle);
+  EXPECT_FALSE(result);
+
+  // invalid limits (lower > upper)
+  result = angles::shortest_angular_distance_with_limits(0, 0.1, 2*M_PI, -2*M_PI, shortest_angle);
+  EXPECT_FALSE(result);
+
+  // specific test case
+  result = angles::shortest_angular_distance_with_limits(0.999507, 1.0, -20*M_PI, 20*M_PI, shortest_angle);
+  EXPECT_TRUE(result);
+  EXPECT_NEAR(shortest_angle, 0.000493, 1e-6);
+}
+
+
 TEST(Angles, from_degrees)
 {
   double epsilon = 1e-9;
@@ -160,7 +195,7 @@ TEST(Angles, normalize_angle)
  EXPECT_NEAR(M_PI/2, normalize_angle(5*M_PI/2), epsilon);
  EXPECT_NEAR(M_PI/2, normalize_angle(9*M_PI/2), epsilon);
  EXPECT_NEAR(M_PI/2, normalize_angle(-3*M_PI/2), epsilon);
- 
+
 }
 
 TEST(Angles, shortest_angular_distance)

--- a/angles/test/utest.py
+++ b/angles/test/utest.py
@@ -32,7 +32,7 @@
 #  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
 #********************************************************************/
-from angles import normalize_angle_positive, normalize_angle, shortest_angular_distance, two_pi_complement, shortest_angular_distance_with_limits
+from angles import normalize_angle_positive, normalize_angle, shortest_angular_distance, two_pi_complement, shortest_angular_distance_with_limits, shortest_angular_distance_with_large_limits
 from angles import _find_min_max_delta
 import sys
 import unittest
@@ -106,6 +106,34 @@ class TestAngles(unittest.TestCase):
         result, shortest_angle = shortest_angular_distance_with_limits(-pi, pi,-pi,pi)
         self.assertTrue(result)
         self.assertAlmostEqual(shortest_angle,0.0)
+    
+    def test_shortestDistanceWithLargeLimits(self):
+        # 'delta' is valid
+        result, shortest_angle = shortest_angular_distance_with_large_limits(0, 10.5*pi, -2*pi, 2*pi)
+        self.assertTrue(result)
+        self.assertAlmostEqual(shortest_angle, 0.5*pi)
+
+        # 'delta' is not valid, but 'delta_2pi' is
+        result, shortest_angle = shortest_angular_distance_with_large_limits(0, 10.5*pi, -2*pi, 0.1*pi)
+        self.assertTrue(result)
+        self.assertAlmostEqual(shortest_angle, -1.5*pi)
+
+        # neither 'delta' nor 'delta_2pi' are valid
+        result, shortest_angle = shortest_angular_distance_with_large_limits(2*pi, pi, 2*pi-0.1, 2*pi+0.1)
+        self.assertFalse(result)
+
+        # start position outside limits
+        result, shortest_angle = shortest_angular_distance_with_large_limits(10.5*pi, 0, -2*pi, 2*pi)
+        self.assertFalse(result)
+
+        # invalid limits (lower > upper)
+        result, shortest_angle = shortest_angular_distance_with_large_limits(0, 0.1, 2*pi, -2*pi)
+        self.assertFalse(result)
+
+        # specific test case
+        result, shortest_angle = shortest_angular_distance_with_large_limits(0.999507, 1.0, -20*pi, 20*pi)
+        self.assertTrue(result)
+        self.assertAlmostEqual(shortest_angle, 0.000493)
 
     def test_normalize_angle_positive(self):
         self.assertAlmostEqual(0, normalize_angle_positive(0))


### PR DESCRIPTION
This PR proposes a new function to deal with shortest angle calculations in presence of "*large limits*", *i.e.*, when either `left_limit` or `right_limit` are outside the range `[ -pi , pi ]`.

### Motivating example

While using the `effort_controllers/JointGroupPositionController`, I experienced an issue similar to #2. In my specific case,  a call to `shortest_angular_distance_with_limits` was performed with:
```
from = 0.999507
to = 1.0
left_limit = -62.831853 (-20*pi)
right_limit = 62.831853 (20*pi)
```
the function returned `false`, and the angle was evaluated to `-6.282692`. This is not really an error, since it is written in the documentation that limits are supposed to be within `-pi` and `+pi` and in addition the function returned `false`. However, the validity of the limits is not checked inside `shortest_angular_distance_with_limits`, and thus it's user's responsibility to make sure that such calls are not performed.

I however think that having `shortest_angular_distance_with_limits` to work with bounds in `[ -pi , pi ]` is a strong limitation. I am aware that having limits in a range such as `[ -20*pi , 20*pi ]` for a revolute joint is uncommon and that a continuous joint would solve the issue without posing many limitations. Nonetheless, I think it would be more robust to explicitly add support for "large limits".

### Proposed solution

I implemented the function `shortest_angular_distance_with_large_limits`, which is supposed to work with bounds larger than `pi`.

The main difference with `shortest_angular_distance_with_limits` is that it does not allow "*reversed bounds*" such as `[ 0.75*pi , -0.75*pi ]`. Reverse bounds make sense in the unit circle where the rotation `x+2*pi` is considered exactly the same as `x`. However, I believe the same should not be true when considering larger bounds, and my function thus requires `left_limit < right_limit`.

The goal of the function is to return the smallest angle `x` such that `fmod(from+x, 2*pi)` equals `fmod(to, 2*pi)` also ensuring that `left_limit <= from+x <= right_limit`. Note that `to` does not need to be in the valid interval. As an example, `shortest_angular_distance_with_limits(0, 0.5*pi, -2*pi, 2*pi, sa)` will return `true` with `sa=0.5*pi`, while `shortest_angular_distance_with_limits(0, 0.5*pi, -2*pi, 0.1*pi, sa)` will return `true` with `sa=-1.5*pi` (since `0.5*pi` is larger than `right_limit`).

I propose to let `shortest_angular_distance_with_limits` automatically call the new function whenever a bound is larger than `pi` (in magnitude). Since I know this might break back-compatibility in many ways, I am open to alternative solutions!

### Minor changes

- Added few tests in angles/test/utest.cpp
- Added the `pthread` flag in angles/test/CMakeLists.txt - I had linker errors while building the tests, and followed what reported in [gtest's wiki page](http://wiki.ros.org/gtest#Building_and_running_tests)