### PR TITLE
Update the angle normalization function to a simpler implementation

### DIFF
--- a/angles/include/angles/angles.h
+++ b/angles/include/angles/angles.h
@@ -67,7 +67,7 @@ namespace angles
    */
   static inline double normalize_angle_positive(double angle)
   {
-    const double result = fmod(angle, 2*M_PI);
+    const double result = fmod(angle, 2.0*M_PI);
     if(result < 0) return result + 2.0*M_PI;
     return result;
   }
@@ -82,9 +82,9 @@ namespace angles
    */
   static inline double normalize_angle(double angle)
   {
-    const double result = fmod(angle + M_PI, 2*M_PI);
-    // if(result < 0) return result + M_PI; // Fits the python refactor
-    if(result <= 0) return result + M_PI;
+    const double result = fmod(angle + M_PI, 2.0*M_PI);
+    // if(result < 0.0) return result + M_PI; // Fits the python refactor
+    if(result <= 0.0) return result + M_PI;
     return result - M_PI;
   }
 

--- a/angles/include/angles/angles.h
+++ b/angles/include/angles/angles.h
@@ -83,7 +83,6 @@ namespace angles
   static inline double normalize_angle(double angle)
   {
     const double result = fmod(angle + M_PI, 2.0*M_PI);
-    // if(result < 0.0) return result + M_PI; // Fits the python refactor
     if(result <= 0.0) return result + M_PI;
     return result - M_PI;
   }

--- a/angles/include/angles/angles.h
+++ b/angles/include/angles/angles.h
@@ -67,7 +67,9 @@ namespace angles
    */
   static inline double normalize_angle_positive(double angle)
   {
-    return fmod(fmod(angle, 2.0*M_PI) + 2.0*M_PI, 2.0*M_PI);
+    const double result = fmod(angle, 2*M_PI);
+    if(result < 0) return result + 2.0*M_PI;
+    return result;
   }
 
 
@@ -80,10 +82,10 @@ namespace angles
    */
   static inline double normalize_angle(double angle)
   {
-    double a = normalize_angle_positive(angle);
-    if (a > M_PI)
-      a -= 2.0 *M_PI;
-    return a;
+    const double result = fmod(angle + M_PI, 2*M_PI);
+    // if(result < 0) return result + M_PI; // Fits the python refactor
+    if(result <= 0) return result + M_PI;
+    return result - M_PI;
   }
 
 

--- a/angles/src/angles/__init__.py
+++ b/angles/src/angles/__init__.py
@@ -37,7 +37,7 @@ from math import fmod, pi, fabs
 def normalize_angle_positive(angle):
     """ Normalizes the angle to be 0 to 2*pi
         It takes and returns radians. """
-    return fmod(fmod(angle, 2.0*pi) + 2.0*pi, 2.0*pi)
+    return angle % (2.0*pi)
 
 def normalize_angle(angle):
     """ Normalizes the angle to be -pi to +pi

--- a/angles/src/angles/__init__.py
+++ b/angles/src/angles/__init__.py
@@ -42,7 +42,10 @@ def normalize_angle_positive(angle):
 def normalize_angle(angle):
     """ Normalizes the angle to be -pi to +pi
         It takes and returns radians."""
-    return (angle + pi) % (2.0*pi) - pi
+    a = normalize_angle_positive(angle)
+    if a > pi:
+        a -= 2.0 *pi
+    return a
 
 def shortest_angular_distance(from_angle, to_angle):
     """ Given 2 angles, this returns the shortest angular

--- a/angles/src/angles/__init__.py
+++ b/angles/src/angles/__init__.py
@@ -34,18 +34,10 @@
 
 from math import fmod, pi, fabs
 
-def normalize_angle_positive(angle):
-    """ Normalizes the angle to be 0 to 2*pi
-        It takes and returns radians. """
-    return fmod(fmod(angle, 2.0*pi) + 2.0*pi, 2.0*pi)
-
 def normalize_angle(angle):
     """ Normalizes the angle to be -pi to +pi
         It takes and returns radians."""
-    a = normalize_angle_positive(angle)
-    if a > pi:
-        a -= 2.0 *pi
-    return a
+    return (angle + pi) % (2*pi) - pi
 
 def shortest_angular_distance(from_angle, to_angle):
     """ Given 2 angles, this returns the shortest angular

--- a/angles/src/angles/__init__.py
+++ b/angles/src/angles/__init__.py
@@ -34,10 +34,15 @@
 
 from math import fmod, pi, fabs
 
+def normalize_angle_positive(angle):
+    """ Normalizes the angle to be 0 to 2*pi
+        It takes and returns radians. """
+    return fmod(fmod(angle, 2.0*pi) + 2.0*pi, 2.0*pi)
+
 def normalize_angle(angle):
     """ Normalizes the angle to be -pi to +pi
         It takes and returns radians."""
-    return (angle + pi) % (2*pi) - pi
+    return (angle + pi) % (2.0*pi) - pi
 
 def shortest_angular_distance(from_angle, to_angle):
     """ Given 2 angles, this returns the shortest angular


### PR DESCRIPTION
This is a proposal to simplify the implementation of the angle normalization.

The only difference it for the case of `(1+2*N)*pi` where the new implementation will give `-3.141592653589793` and the old implementation give `3.141592653589793`. 

The new implementation is about twice as fast as per the code below suggests.

```python
from timeit import timeit

setup1 = '''
from math import fmod, pi, fabs

def normalize_angle(angle):
  return (angle + pi) % (2*pi) - pi
'''

setup2 = '''
from math import fmod, pi, fabs
def normalize_angle_positive(angle):
    """ Normalizes the angle to be 0 to 2*pi
        It takes and returns radians. """
    return fmod(fmod(angle, 2.0*pi) + 2.0*pi, 2.0*pi)

def normalize_angle(angle):
    """ Normalizes the angle to be -pi to +pi
        It takes and returns radians."""
    a = normalize_angle_positive(angle)
    if a > pi:
        a -= 2.0 *pi
    return a
'''

timeit(setup = setup1, stmt = "normalize_angle(pi)")
timeit(setup = setup2, stmt = "normalize_angle(pi)")
```

Behaviour testing: https://repl.it/@AlexisTM/Behaviour-testing