### PR TITLE
Bump CMake version to avoid CMP0048 warning

### DIFF
--- a/angles/CMakeLists.txt
+++ b/angles/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0.2)
 project(angles)
 
 find_package(catkin REQUIRED)


### PR DESCRIPTION
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

http://build.ros.org/view/Ndoc/job/Ndoc__angles__ubuntu_focal_amd64/4/console

```
00:04:25.667 ==> Processing catkin package: 'angles'
00:04:25.668 ==> Creating build directory: 'build_isolated/angles'
00:04:25.668 ==> cmake /tmp/ws/src/angles/angles -DCATKIN_DEVEL_PREFIX=/tmp/ws/devel_isolated/angles -DCMAKE_INSTALL_PREFIX=/tmp/ws/install_isolated -DCATKIN_SKIP_TESTING=1 -G Unix Makefiles in '/tmp/ws/build_isolated/angles'
00:04:25.681 -- Using CATKIN_DEVEL_PREFIX: /tmp/ws/devel_isolated/angles
00:04:25.682 -- Using CMAKE_PREFIX_PATH: /opt/ros/noetic
00:04:25.682 -- This workspace overlays: /opt/ros/noetic
00:04:25.759 -- The C compiler identification is GNU 9.2.1
00:04:25.851 -- The CXX compiler identification is GNU 9.2.1
00:04:25.861 -- Check for working C compiler: /usr/bin/cc
00:04:25.967 -- Check for working C compiler: /usr/bin/cc -- works
00:04:25.968 -- Detecting C compiler ABI info
00:04:26.059 -- Detecting C compiler ABI info - done
00:04:26.075 -- Detecting C compile features
00:04:26.076 -- Detecting C compile features - done
00:04:26.081 -- Check for working CXX compiler: /usr/bin/c++
00:04:26.186 -- Check for working CXX compiler: /usr/bin/c++ -- works
00:04:26.190 -- Detecting CXX compiler ABI info
00:04:26.294 -- Detecting CXX compiler ABI info - done
00:04:26.314 -- Detecting CXX compile features
00:04:26.316 -- Detecting CXX compile features - done
00:04:26.342 -- Found PythonInterp: /usr/bin/python3.8 (found version "3.8.2") 
00:04:26.343 -- Using PYTHON_EXECUTABLE: /usr/bin/python3.8
00:04:26.343 -- Using Debian Python package layout
00:04:26.398 -- Found PY_em: /usr/lib/python3/dist-packages/em.py  
00:04:26.398 -- Using empy: /usr/lib/python3/dist-packages/em.py
00:04:26.398 -- Using CATKIN_SKIP_TESTING: 1 (implying CATKIN_ENABLE_TESTING=OFF)
00:04:26.398 -- Call enable_testing()
00:04:26.402 -- Using CATKIN_TEST_RESULTS_DIR: /tmp/ws/build_isolated/angles/test_results
00:04:26.944 -- Forcing gtest/gmock from source, though one was otherwise available.
00:04:26.946 -- Found gtest sources under '/usr/src/googletest': gtests will be built
00:04:26.946 -- Found gmock sources under '/usr/src/googletest': gmock will be built
00:04:26.975 -- Found Threads: TRUE  
00:04:26.985 -- Using Python nosetests: /usr/bin/nosetests3
00:04:27.060 -- catkin 0.8.1
00:04:27.060 -- BUILD_SHARED_LIBS is on
00:04:27.274 CMake Warning (dev) at CMakeLists.txt:14 (project):
00:04:27.274   Policy CMP0048 is not set: project() command manages VERSION variables.
00:04:27.274   Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
00:04:27.274   command to set the policy and suppress this warning.
00:04:27.275 
00:04:27.275   The following variable(s) would be set to empty:
00:04:27.275 
00:04:27.275     angles_VERSION
00:04:27.275     CMAKE_PROJECT_VERSION
00:04:27.275     CMAKE_PROJECT_VERSION_MAJOR
00:04:27.275     CMAKE_PROJECT_VERSION_MINOR
00:04:27.275     CMAKE_PROJECT_VERSION_PATCH
00:04:27.275 This warning is for project developers.  Use -Wno-dev to suppress it.
```

ros/catkin#1052