### PR TITLE
[noetic port] Use setuptools instead of distutils

### DIFF
--- a/angles/package.xml
+++ b/angles/package.xml
@@ -1,4 +1,8 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>angles</name>
   <version>1.9.13</version>
   <description>This package provides a set of simple math utilities to work
@@ -17,6 +21,8 @@
   <url>http://wiki.ros.org/angles</url>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
   <test_depend>rosunit</test_depend>
 
   <export>

--- a/angles/setup.py
+++ b/angles/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 package_info = generate_distutils_setup(


### PR DESCRIPTION
This pull request is to apply the `noetic` migration by this ROS Wiki: http://wiki.ros.org/noetic/Migration

P.S. Updating it to `setuptools` helps packaging system such like `conda` packages passing `--single-version-externally-managed` to avoid Python `egg` generation.  