### PR TITLE
Install includes to include/${PROJECT_NAME} and export library target

### DIFF
--- a/angles/CMakeLists.txt
+++ b/angles/CMakeLists.txt
@@ -13,12 +13,13 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
-install(DIRECTORY include/${PROJECT_NAME}/
-        DESTINATION include/${PROJECT_NAME}/
-        FILES_MATCHING PATTERN "*.h")
+add_library(angles INTERFACE)
+target_link_libraries(angles INTERFACE
+  "$<INSTALL_INTERFACE:install/angles>")
+install(TARGETS angles EXPORT export_angles)
 
-include_directories(include)
+ament_export_targets(export_angles)
 
-ament_export_include_directories(include)
+install(DIRECTORY include/ DESTINATION include/angles)
 
 ament_package()


### PR DESCRIPTION
This installs includes to `include/${PROJECT_NAME}` to mitigate include directory search order issues when overriding packages in `desktop`.

It also replaces the old-style CMake variable export with a modern CMake target export. Dependencies using `ament_target_dependencies(MyTarget angles)` will still work, but now they can use modern CMake targets instead.

```cmake
target_link_libraries(MyTarget PRIVATE angles::angles)
```

Part of ros2/ros2#1150
Part of ament/ament_cmake#365