### PR TITLE
fix header installation path

### DIFF
--- a/angles/CMakeLists.txt
+++ b/angles/CMakeLists.txt
@@ -20,6 +20,6 @@ install(TARGETS angles EXPORT export_angles)
 
 ament_export_targets(export_angles)
 
-install(DIRECTORY include/ DESTINATION include/angles)
+install(DIRECTORY include/ DESTINATION include)
 
 ament_package()


### PR DESCRIPTION
fixes header installation path in https://github.com/ros/angles/commit/1c07a742376ea0b0c8795b278f091e8ecac93e14 for #28 