### PR TITLE
target_link_libraries -> target_include_directories

### DIFF
--- a/angles/CMakeLists.txt
+++ b/angles/CMakeLists.txt
@@ -14,8 +14,8 @@ endif()
 find_package(ament_cmake REQUIRED)
 
 add_library(angles INTERFACE)
-target_link_libraries(angles INTERFACE
-  "$<INSTALL_INTERFACE:install/angles>")
+target_include_directories(angles INTERFACE
+  "$<INSTALL_INTERFACE:include/angles>")
 install(TARGETS angles EXPORT export_angles)
 
 ament_export_targets(export_angles)

--- a/angles/CMakeLists.txt
+++ b/angles/CMakeLists.txt
@@ -18,6 +18,9 @@ target_include_directories(angles INTERFACE
   "$<INSTALL_INTERFACE:include/angles>")
 install(TARGETS angles EXPORT export_angles)
 
+# TODO(sloretz) remove when old-style CMake interface is no longer supported
+ament_export_include_directories("include/angles")
+
 ament_export_targets(export_angles)
 
 install(DIRECTORY include/ DESTINATION include/angles)

--- a/angles/package.xml
+++ b/angles/package.xml
@@ -23,6 +23,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>python3-setuptools</buildtool_depend>
 
+  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
#28 is broken after all. The interface target isn't properly exporting the include directory.

I also added back the creation of the old-style CMake variable `angles_INCLUDE_DIR` to minimize disruption.

@asobhy-qnx @domire8 FYI
