### PR TITLE
Fix M_PI on Windows

### DIFF
--- a/angles/include/angles/angles.h
+++ b/angles/include/angles/angles.h
@@ -35,6 +35,7 @@
 #ifndef GEOMETRY_ANGLES_UTILS_H
 #define GEOMETRY_ANGLES_UTILS_H
 
+#define _USE_MATH_DEFINES
 #include <algorithm>
 #include <cmath>
 


### PR DESCRIPTION
On Windows, in order to use M_PI, `_USE_MATH_DEFINES` must be defined. Since `M_PI` is used in a header file, I think it should be defined at the top instead of requiring any downstream packages using this library to define it themselves.