### PR TITLE
Ensure that M_PI is defined in any downstream compilation unit in Windows

### DIFF
--- a/angles/CMakeLists.txt
+++ b/angles/CMakeLists.txt
@@ -16,6 +16,9 @@ find_package(ament_cmake REQUIRED)
 add_library(angles INTERFACE)
 target_include_directories(angles INTERFACE
   "$<INSTALL_INTERFACE:include/angles>")
+if(WIN32)
+  target_compile_definitions(angles INTERFACE _USE_MATH_DEFINES)
+endif()
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/angles/include/angles/angles.h
+++ b/angles/include/angles/angles.h
@@ -35,7 +35,10 @@
 #ifndef GEOMETRY_ANGLES_UTILS_H
 #define GEOMETRY_ANGLES_UTILS_H
 
+#ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
+#endif
+
 #include <algorithm>
 #include <cmath>
 


### PR DESCRIPTION
The PR https://github.com/ros/angles/pull/34 fixed the use of `angles` in some downstream compilation units, but not in all of them. The problem is that in this project `M_PI` is used in a public header, so just adding `#define _USE_MATH_DEFINES` in the header works if a compilation unit uses this header as:

~~~cxx
#include <angles/angles.h>

#include <cmath>
~~~

but will fail if it is used as:

~~~cxx
#include <cmath>

#include <angles/angles.h>
~~~

as in the second case, `_USE_MATH_DEFINES` is defined once math.h was already included, and so it is not possible to "retroactively" set it. 

To ensure that `_USE_MATH_DEFINES` is always defined, we set it via CMake. I also left the `_USE_MATH_DEFINES` defined in the code to avoid breaking downstream consumers that do not use CMake, but I wrapped it with `#ifndef _USE_MATH_DEFINES` to avoid warnings.