### PR TITLE
Update compile requirements

### DIFF
--- a/angles/CMakeLists.txt
+++ b/angles/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14.4)
 project(angles)
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # we dont use add_compile_options with pedantic in message packages


### PR DESCRIPTION
Humble Hawksbill (May 2022 - May 2027) : https://www.ros.org/reps/rep-2000.html

requirements:
Cxx standard 17
min cmake 3.14.4  (also fix cmake <3.10 deprecations)